### PR TITLE
Fix container packaging bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "torch>=2.6.0",
     "torchvision>=0.5.0",
     "tensordict>=0.7.0",
+    "packaging<24",
     "numpy>=1.16.4",
     "GitPython",
     "onnx",


### PR DESCRIPTION
Require packaging<24 (fixes error when building Docker image)